### PR TITLE
Refactor: simplify existing and (especially) unused code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-cython
-matplotlib
-numpy
-pandas
-scipy
+colorlog

--- a/src/storygen/app.py
+++ b/src/storygen/app.py
@@ -1,13 +1,14 @@
 #! /usr/bin/env python
+import bisect
+import json
+import logging
 import random
-from bisect import bisect
+from dataclasses import dataclass
+from typing import Callable
 
+from storygen.log import get_logger
 
-class PhonemePosition:
-    START = 1
-    END = -1
-    INTERIOR = 2
-    ANY = 0
+logger = get_logger("storygen.app")
 
 
 def weighted_dict_to_cummulative_distribution(choice_dct):
@@ -20,83 +21,134 @@ def weighted_dict_to_cummulative_distribution(choice_dct):
     return keys, cdf
 
 
-def gen_name(weighted_transitions):
-    transition_probs = {
-        k: weighted_dict_to_cummulative_distribution(d)
-        for k, d in weighted_transitions.items()
-    }
+@dataclass
+class LanguageSpec:
+    phonemes: list[str]
+    min_name_length: int = 4
+    brevity_factor: int = random.randint(10, 80)
 
-    phonemes = []
-    state = None
-    for i in range(5):
-        try:
-            possible_phonemes, cdf = transition_probs[state]
-        except KeyError:
-            if not phonemes:
+
+class Language:
+    def __init__(self, spec: LanguageSpec):
+        self.spec = spec
+
+        phonemes = set(spec.phonemes)
+
+        self.initial_phonemes = set(random.sample(tuple(phonemes), len(phonemes) // 4))
+        self.ending_phonemes = set(random.sample(tuple(phonemes - self.initial_phonemes), len(phonemes) // 4))
+        self.other_phonemes = phonemes - self.initial_phonemes - self.ending_phonemes
+
+        # Calculate weighted transitions for phonemes chosen as prefixes
+        self.weighted_transitions = {
+            None: {
+                p: random.randint(3, 10) for p in self.initial_phonemes
+            }
+        }
+
+        # Calculate weighted transitions for phonemes not chosen as prefixes nor suffixes
+        for phoneme in self.other_phonemes.union(self.initial_phonemes):
+            self.weighted_transitions[phoneme] = {
+                p: random.randint(3, 10) for p in self.other_phonemes.union(self.ending_phonemes)
+            }
+            self.weighted_transitions[phoneme][None] = spec.brevity_factor
+
+        # Calculate weighted transitions for phonemes chosen as suffixes
+        for phoneme in self.ending_phonemes:
+            self.weighted_transitions[phoneme] = {None: 1000}
+
+    def gen_name(self):
+        transition_probs = {
+            k: weighted_dict_to_cummulative_distribution(d)
+            for k, d in self.weighted_transitions.items()
+        }
+
+        phonemes = []
+        state = None
+        for i in range(5):
+            try:
+                possible_phonemes, cdf = transition_probs[state]
+            except KeyError:
+                if not phonemes:
+                    continue
+                break
+            x = random.random()
+            b = bisect.bisect(cdf, x)
+            p = possible_phonemes[b]
+            if p is None:
+                break
+            phonemes.append(p)
+            state = p
+
+        return "".join(phonemes)
+
+    def gen_names(self, n=10):
+        names = set()
+        for i in range(n ** 3):
+            name = self.gen_name()
+            if len(name) < self.spec.min_name_length:
                 continue
-            break
-        x = random.random()
-        b = bisect(cdf, x)
-        p = possible_phonemes[b]
-        if p is None:
-            break
-        phonemes.append(p)
-        state = p
-
-    return "".join(phonemes)
+            names.add(name)
+            if len(names) >= n:
+                break
+        return names
 
 
-def gen_names(weighted_transitions, n=10, min_length=4):
-    names = set()
-    for i in range(n*n):
-        name = gen_name(weighted_transitions)
-        if len(name) < min_length:
-            continue
-        names.add(name)
-        if len(names) >= n:
-            break
-    return names
+class NameFormats:
+
+    @classmethod
+    def default(cls, first, last):
+        return cls.first_space_last(first, last)
+
+    @classmethod
+    def first_space_last(cls, first, last):
+        return f"{first} {last}"
+
+    @classmethod
+    def last_comma_first(cls, first, last):
+        return f"{last}, {first}"
 
 
-def gen_language(phonemes, brevity_factor=10):
-    phonemes = set(phonemes)
-    initial_phonemes = set(random.sample(phonemes, len(phonemes)//4))
-    ending_phonemes = set(random.sample(phonemes - initial_phonemes, len(phonemes)//4))
-    other_phonemes = phonemes - initial_phonemes - ending_phonemes
-    weighted_transitions = {
-        None: {
-            p: random.randint(3, 10) for p in initial_phonemes
-        }
-    }
-    for phoneme in other_phonemes.union(initial_phonemes):
-        weighted_transitions[phoneme] = {
-            p: random.randint(3, 10) for p in other_phonemes.union(ending_phonemes)
-        }
-        weighted_transitions[phoneme][None] = brevity_factor
-    for phoneme in ending_phonemes:
-        weighted_transitions[phoneme] = {
-            None: 1
-        }
-    return weighted_transitions
+NameFormatter = Callable[[str, str], str]
 
 
-def main():
-    phonemes = {
+def gen_full_names(language, num_last_names=3, num_first_names=5):
+    for last_name in language.gen_names(n=num_last_names):
+        for first_name in language.gen_names(n=num_first_names):
+            yield last_name, first_name
+
+
+def main(
+    full_name_format: NameFormatter = NameFormats.default,
+    num_last_names: int = 30,
+    num_first_names: int = 10,
+):
+    from storygen.log import init_logging
+
+    init_logging()
+
+    phonemes = (
         "bra", "kah", "to", "ro", "for", "mo", "ter", "je", "jo", "mel",
         "din", "ger", "tog", "tag", "nar", "bar", "la",
-        "sha", "ial", "bia", "fra", "dar", "mis", "fang", "ke", "ike", "pyke",
-        "el", "pia", "del", "er", "es", "qi", "nin"
-    }
-    first_name_language = gen_language(phonemes, brevity_factor=1000)
-    last_name_language = gen_language(phonemes)
-    # pprint(first_name_language)
+        "sha", "ial", "bia", "fra", "dar", "mis", "fang",
+        "ke", "ike", "ye", "ya", "yek", "el", "pia", "del", "er", "es",
+        "qi", "nin",
+    )
+    phonemes = sorted(set(phonemes))
 
-    first_names = gen_names(first_name_language, n=1000, min_length=4)
-    # first_names = sorted(first_names)
-    last_names = list(gen_names(last_name_language, n=200, min_length=4))*5
-    last_names = sorted(last_names)
-    for first_name, last_name in zip(first_names, last_names):
-        print("{} {}".format(first_name.title(), last_name.title()))
+    spec = LanguageSpec(phonemes=phonemes)
+    logger.debug("language spec: %s", spec)
+
+    language = Language(spec)
+
+    names = gen_full_names(
+        language,
+        num_last_names=num_last_names,
+        num_first_names=num_first_names,
+    )
+
+    for i, (last_name, first_name) in enumerate(names):
+        full_name = full_name_format(first_name, last_name)
+        logger.info(f"{i+1:04d}    {full_name.title()}")
 
 
 if __name__ == "__main__":

--- a/src/storygen/log.py
+++ b/src/storygen/log.py
@@ -1,0 +1,65 @@
+import logging
+
+import colorlog as colorlog
+
+__all__ = [
+    "init_logging",
+    "get_logger",
+    "LOG_FORMAT_DEBUG",
+    "LOG_FORMAT_CONCISE",
+]
+
+
+LOG_LEVEL = logging.DEBUG
+LOG_FORMAT_DEBUG = "[%(asctime)s %s(levelname)] (%(name)s:%(lineno)s) %(message)s"
+LOG_FORMAT_CONCISE = "%(message)s"
+LOG_FORMAT = LOG_FORMAT_CONCISE
+
+
+root_logger = logging.getLogger()
+
+
+def init_root_logger(level, fmt):
+    colored_formatter = colorlog.ColoredFormatter(
+        '%(log_color)s' + fmt,
+        log_colors={
+            "DEBUG": "white",
+            "INFO": "blue",
+            "WARNING": "yellow",
+            "ERROR": "red",
+            "CRITICAL": "bold_red",
+        }
+    )
+    stdio_handler = colorlog.StreamHandler()
+    stdio_handler.setFormatter(colored_formatter)
+    root_logger.addHandler(stdio_handler)
+    root_logger.setLevel(level)
+
+
+def init_logging(level=LOG_LEVEL, fmt=LOG_FORMAT, force=False):
+    if (not force) and root_logger.handlers:
+        return
+    init_root_logger(level, fmt)
+
+
+def get_logger(name, level=None):
+    logger = logging.getLogger(name)
+    if level is not None:
+        logger.setLevel(level)
+    return logger
+
+
+logger = get_logger("storygen.log")
+
+
+def main():
+    init_logging()
+    logger.debug("Logging initialized")
+    logger.info("Logging initialized")
+    logger.warning("Logging initialized")
+    logger.error("Logging initialized")
+    logger.critical("Logging initialized")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/storygen/utility/probability.py
+++ b/src/storygen/utility/probability.py
@@ -57,6 +57,16 @@ class DistributionFunction:
         return y
 
 
+def weighted_dict_to_cummulative_distribution(choice_dct):
+    keys, weights = zip(*choice_dct.items())
+    total = float(sum(weights))
+    probs = [v/total for v in weights]
+    cdf = [probs[0]]
+    for i in range(1, len(probs)):
+        cdf.append(cdf[-1] + probs[i])
+    return keys, cdf
+
+
 class MarkovChain:
 
     def __init__(self, state_mapping, start=ALPHA, end=OMEGA):
@@ -80,12 +90,7 @@ class MarkovChain:
     def from_weights(cls, weights):
         d = OrderedDict()
         for k, choice_dct in weights.items():
-            keys, weights = zip(*choice_dct.items())
-            total = float(sum(weights))
-            probs = [v/total for v in weights]
-            cdf = [probs[0]]
-            for i in range(1, len(probs)):
-                cdf.append(cdf[-1] + probs[i])
+            keys, cdf = weighted_dict_to_cummulative_distribution(choice_dct)
             d[k] = keys, cdf
         return cls(d)
 


### PR DESCRIPTION
This iteration of `storygen` was put on hiatus in an overly optimistic/ambitious state. I had added a bunch of library code, but never integrated it with anything. On the other hand, `app.py` was left as to be useful by itself. I have made some minor improvements to it, and it will form the basis of a refactor.

Every time I've wanted to use the name generation functionality for another project, it's too messy for comfort. So the goal here is to refactor down to the basics, and only add features as needed going forward.